### PR TITLE
Correct README.md resume serve command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This will read the local `package.json` and install the packages listed under `d
 While inside the theme folder, simply run:
 
 ```
-resume serve
+resume serve --theme .
 ```
 
 You should now see this message:


### PR DESCRIPTION
As mentioned in #22, resume serve command should fit the cli feature for serve the local theme, otherwise it will serve with jsonresume-theme-even by default.

https://github.com/jsonresume/resume-cli#resume-serve

> When developing themes, simply change into your theme directory and run resume serve --theme . (which tells it to run the local folder as the specified theme)